### PR TITLE
feat: doc fixes, make get/has fns more widely useful

### DIFF
--- a/packages/ts-types/src/narrowing/get.ts
+++ b/packages/ts-types/src/narrowing/get.ts
@@ -5,17 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-  AnyArray,
-  AnyConstructor,
-  AnyFunction,
-  AnyJson,
-  JsonArray,
-  JsonCollection,
-  JsonMap,
-  Nullable,
-  Optional
-} from '../types';
+import { AnyArray, AnyConstructor, AnyFunction, AnyJson, JsonArray, JsonMap, Nullable, Optional } from '../types';
 import {
   asArray,
   asBoolean,
@@ -51,11 +41,11 @@ import { valueOrDefault } from './internal';
  * // type of value -> unknown; value === 'baz'
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function get(from: Nullable<object>, path: string, defaultValue?: unknown): unknown {
+export function get(from: unknown, path: string, defaultValue?: unknown): unknown {
   return valueOrDefault(
     path
       .split(/[\.\[\]\'\"]/)
@@ -75,10 +65,10 @@ export function get(from: Nullable<object>, path: string, defaultValue?: unknown
  * // type of value -> string; value -> 'baz'
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  */
-export function getString(from: Nullable<object>, path: string): Nullable<string>;
+export function getString(from: unknown, path: string): Nullable<string>;
 /**
  * Given a deep-search query path, returns an object property or array value of an object or array as a `string`, or
  * `undefined` if a value was not found or was not type-compatible.
@@ -89,13 +79,13 @@ export function getString(from: Nullable<object>, path: string): Nullable<string
  * // type of value -> string; value -> 'default'
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getString(from: Nullable<object>, path: string, defaultValue: string): string;
+export function getString(from: unknown, path: string, defaultValue: string): string;
 // underlying function
-export function getString(from: Nullable<object>, path: string, defaultValue?: string): Nullable<string> {
+export function getString(from: unknown, path: string, defaultValue?: string): Nullable<string> {
   return valueOrDefault(asString(get(from, path)), defaultValue);
 }
 
@@ -109,10 +99,10 @@ export function getString(from: Nullable<object>, path: string, defaultValue?: s
  * // type of value -> number; value -> 1
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  */
-export function getNumber(from: Nullable<object>, path: string): Nullable<number>;
+export function getNumber(from: unknown, path: string): Nullable<number>;
 /**
  * Given a deep-search query path, returns an object property or array value of an object or array as a `number`, or
  * `undefined` if a value was not found or was not type-compatible.
@@ -123,13 +113,13 @@ export function getNumber(from: Nullable<object>, path: string): Nullable<number
  * // type of value -> number; value -> 2
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getNumber(from: Nullable<object>, path: string, defaultValue: number): number;
+export function getNumber(from: unknown, path: string, defaultValue: number): number;
 // underlying function
-export function getNumber(from: Nullable<object>, path: string, defaultValue?: number): Nullable<number> {
+export function getNumber(from: unknown, path: string, defaultValue?: number): Nullable<number> {
   return valueOrDefault(asNumber(get(from, path)), defaultValue);
 }
 
@@ -143,10 +133,10 @@ export function getNumber(from: Nullable<object>, path: string, defaultValue?: n
  * // type of value -> boolean; value -> true
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  */
-export function getBoolean(from: Nullable<object>, path: string): Nullable<boolean>;
+export function getBoolean(from: unknown, path: string): Nullable<boolean>;
 /**
  * Given a deep-search query path, returns an object property or array value of an object or array as a `boolean`, or
  * `undefined` if a value was not found or was not type-compatible.
@@ -157,13 +147,13 @@ export function getBoolean(from: Nullable<object>, path: string): Nullable<boole
  * // type of value -> boolean; value -> false
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getBoolean(from: Nullable<object>, path: string, defaultValue: boolean): boolean;
+export function getBoolean(from: unknown, path: string, defaultValue: boolean): boolean;
 // underlying function
-export function getBoolean(from: Nullable<object>, path: string, defaultValue?: boolean): Nullable<boolean> {
+export function getBoolean(from: unknown, path: string, defaultValue?: boolean): Nullable<boolean> {
   return valueOrDefault(asBoolean(get(from, path)), defaultValue);
 }
 
@@ -177,10 +167,10 @@ export function getBoolean(from: Nullable<object>, path: string, defaultValue?: 
  * // type of value -> object; value -> { name: 'baz' }
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  */
-export function getObject(from: Nullable<object>, path: string): Nullable<object>;
+export function getObject(from: unknown, path: string): Nullable<object>;
 /**
  * Given a deep-search query path, returns an object property or array value of an object or array as an `object`, or
  * `undefined` if a value was not found or was not type-compatible.
@@ -191,13 +181,13 @@ export function getObject(from: Nullable<object>, path: string): Nullable<object
  * // type of value -> object; value -> { name: 'buzz' }
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getObject(obj: Nullable<object>, path: string, defaultValue: object): object;
+export function getObject(from: unknown, path: string, defaultValue: object): object;
 // underlying function
-export function getObject(from: Nullable<object>, path: string, defaultValue?: object): Nullable<object> {
+export function getObject(from: unknown, path: string, defaultValue?: object): Nullable<object> {
   return valueOrDefault(asObject(get(from, path)), defaultValue);
 }
 
@@ -212,10 +202,10 @@ export function getObject(from: Nullable<object>, path: string, defaultValue?: o
  * // type of value -> object; value -> { name: 'baz' }
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  */
-export function getPlainObject(from: Nullable<object>, path: string): Nullable<object>;
+export function getPlainObject(from: unknown, path: string): Nullable<object>;
 /**
  * Given a deep-search query path, returns an object property or array value of an object or array as an `object`, or
  * `undefined` if a value was not found or was not type-compatible. This differs from {@link getObject} by way of
@@ -227,13 +217,13 @@ export function getPlainObject(from: Nullable<object>, path: string): Nullable<o
  * // type of value -> object; value -> { name: 'buzz' }
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getPlainObject(obj: Nullable<object>, path: string, defaultValue: object): object;
+export function getPlainObject(from: unknown, path: string, defaultValue: object): object;
 // underlying function
-export function getPlainObject(from: Nullable<object>, path: string, defaultValue?: object): Nullable<object> {
+export function getPlainObject(from: unknown, path: string, defaultValue?: object): Nullable<object> {
   return valueOrDefault(asPlainObject(get(from, path)), defaultValue);
 }
 
@@ -248,14 +238,10 @@ export function getPlainObject(from: Nullable<object>, path: string, defaultValu
  * // type of value -> Example
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  */
-export function getInstance<C extends AnyConstructor>(
-  from: Nullable<object>,
-  path: string,
-  ctor: C
-): Nullable<InstanceType<C>>;
+export function getInstance<C extends AnyConstructor>(from: unknown, path: string, ctor: C): Nullable<InstanceType<C>>;
 /**
  * Given a deep-search query path, returns an object property or array value of an object or array as an instance of
  * class type `C`, or `undefined` if a value was not found or was not type-compatible.
@@ -267,19 +253,19 @@ export function getInstance<C extends AnyConstructor>(
  * // type of value -> Example; value -> new Example()
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
 export function getInstance<C extends AnyConstructor>(
-  from: Nullable<object>,
+  from: unknown,
   path: string,
   ctor: C,
   defaultValue: InstanceType<C>
 ): InstanceType<C>;
 // underlying function
 export function getInstance<C extends AnyConstructor>(
-  from: Nullable<object>,
+  from: unknown,
   path: string,
   ctor: C,
   defaultValue?: InstanceType<C>
@@ -297,10 +283,10 @@ export function getInstance<C extends AnyConstructor>(
  * // type of value -> AnyArray; value -> [1, 2, 3]
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  */
-export function getArray(from: Nullable<object>, path: string): Nullable<AnyArray>;
+export function getArray(from: unknown, path: string): Nullable<AnyArray>;
 /**
  * Given a deep-search query path, returns an object property or array value of an object or array as an
  * {@link AnyArray}, or `undefined` if a value was not found or was not type-compatible.
@@ -311,13 +297,13 @@ export function getArray(from: Nullable<object>, path: string): Nullable<AnyArra
  * // type of value -> AnyArray; value -> [4, 5, 6]
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getArray(from: Nullable<object>, path: string, defaultValue: AnyArray): AnyArray;
+export function getArray(from: unknown, path: string, defaultValue: AnyArray): AnyArray;
 // underlying function
-export function getArray(from: Nullable<object>, path: string, defaultValue?: AnyArray): Nullable<AnyArray> {
+export function getArray(from: unknown, path: string, defaultValue?: AnyArray): Nullable<AnyArray> {
   return valueOrDefault(asArray(get(from, path)), defaultValue);
 }
 
@@ -331,10 +317,10 @@ export function getArray(from: Nullable<object>, path: string, defaultValue?: An
  * // type of value -> AnyArray; value -> (arg: string) => `Hi, ${arg}`
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  */
-export function getFunction(from: Nullable<object>, path: string): Nullable<AnyFunction>;
+export function getFunction(from: unknown, path: string): Nullable<AnyFunction>;
 /**
  * Given a deep-search query path, returns an object property or array value of an object or array as an
  * {@link AnyFunction}, or `undefined` if a value was not found or was not type-compatible.
@@ -345,13 +331,13 @@ export function getFunction(from: Nullable<object>, path: string): Nullable<AnyF
  * // type of value -> AnyArray; value -> (arg: string) => `Bye, ${arg}`)
  * ```
  *
- * @param from The object or array to query.
+ * @param from Any value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getFunction(from: Nullable<object>, path: string, defaultValue: AnyFunction): AnyFunction;
+export function getFunction(from: unknown, path: string, defaultValue: AnyFunction): AnyFunction;
 // underlying function
-export function getFunction(from: Nullable<object>, path: string, defaultValue?: AnyFunction): Nullable<AnyFunction> {
+export function getFunction(from: unknown, path: string, defaultValue?: AnyFunction): Nullable<AnyFunction> {
   return valueOrDefault(asFunction(get(from, path)), defaultValue);
 }
 
@@ -367,13 +353,13 @@ export function getFunction(from: Nullable<object>, path: string, defaultValue?:
  * // type of value -> AnyJson; value -> { a: 'b' }
  * ```
  *
- * @param from The object or array to query.
+ * @param from The JSON value to query.
  * @param path The query path.
  */
-export function getAnyJson(from: Nullable<JsonCollection>, path: string): Optional<AnyJson>;
+export function getAnyJson(from: Optional<AnyJson>, path: string): Optional<AnyJson>;
 /**
  * Given a deep-search query path, returns an object property or array value of a {@link JsonCollection} as an
- * {@link AnyJson}, or `undefined` if a value was not found or was not type-compatible.
+ * {@link AnyJson}, or the given default if a value was not found or was not type-compatible.
  *
  * ```
  * const obj = { foo: { bar: [{ a: 'b' }] } };
@@ -381,19 +367,19 @@ export function getAnyJson(from: Nullable<JsonCollection>, path: string): Option
  * // type of value -> AnyJson; value -> { c: 'd' }
  * ```
  *
- * @param from The object or array to query.
+ * @param from The JSON value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getAnyJson(from: Nullable<JsonCollection>, path: string, defaultValue: AnyJson): AnyJson;
+export function getAnyJson(from: Optional<AnyJson>, path: string, defaultValue: AnyJson): AnyJson;
 // underlying function
-export function getAnyJson(from: Nullable<JsonCollection>, path: string, defaultValue?: AnyJson): Optional<AnyJson> {
+export function getAnyJson(from: Optional<AnyJson>, path: string, defaultValue?: AnyJson): Optional<AnyJson> {
   return valueOrDefault(coerceAnyJson(get(from, path)), defaultValue);
 }
 
 /**
- * Given a deep-search query path, returns an object property or array value of a {@link JsonCollection} as an
- * {@link AnyJson}, or `undefined` if a value was not found or was not type-compatible.
+ * Given a deep-search query path, returns an object property or array value from an {@link AnyJson} as a
+ * {@link JsonMap}, or `undefined` if a value was not found or was not type-compatible.
  *
  * ```
  * const obj = { foo: { bar: [{ a: 'b' }] } };
@@ -401,13 +387,13 @@ export function getAnyJson(from: Nullable<JsonCollection>, path: string, default
  * // type of value -> JsonMap; value -> { a: 'b' }
  * ```
  *
- * @param from The object or array to query.
+ * @param from The JSON value to query.
  * @param path The query path.
  */
-export function getJsonMap(from: Nullable<JsonCollection>, path: string): Nullable<JsonMap>;
+export function getJsonMap(from: Optional<AnyJson>, path: string): Nullable<JsonMap>;
 /**
- * Given a deep-search query path, returns an object property or array value of a {@link JsonCollection} as an
- * {@link AnyJson}, or `undefined` if a value was not found or was not type-compatible.
+ * Given a deep-search query path, returns an object property or array value from an {@link AnyJson} as a
+ * {@link JsonMap}, or the given default if a value was not found or was not type-compatible.
  *
  * ```
  * const obj = { foo: { bar: [{ a: 'b' }] } };
@@ -415,19 +401,19 @@ export function getJsonMap(from: Nullable<JsonCollection>, path: string): Nullab
  * // type of value -> JsonMap; value -> { c: 'd' }
  * ```
  *
- * @param from The object or array to query.
+ * @param from The JSON value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getJsonMap(from: Nullable<JsonCollection>, path: string, defaultValue: JsonMap): JsonMap;
+export function getJsonMap(from: Optional<AnyJson>, path: string, defaultValue: JsonMap): JsonMap;
 // underlying function
-export function getJsonMap(from: Nullable<JsonCollection>, path: string, defaultValue?: JsonMap): Nullable<JsonMap> {
+export function getJsonMap(from: Optional<AnyJson>, path: string, defaultValue?: JsonMap): Nullable<JsonMap> {
   return valueOrDefault(asJsonMap(getAnyJson(from, path)), defaultValue);
 }
 
 /**
- * Given a deep-search query path, returns an object property or array value of a {@link JsonCollection} as an
- * {@link AnyJson}, or `undefined` if a value was not found or was not type-compatible.
+ * Given a deep-search query path, returns an object property or array value from an {@link AnyJson} as a
+ * {@link JsonArray}, or `undefined` if a value was not found or was not type-compatible.
  *
  * ```
  * const obj = { foo: { bar: [1, 2, 3] } };
@@ -435,13 +421,13 @@ export function getJsonMap(from: Nullable<JsonCollection>, path: string, default
  * // type of value -> JsonArray; value -> [1, 2, 3]
  * ```
  *
- * @param from The object or array to query.
+ * @param from The JSON value to query.
  * @param path The query path.
  */
-export function getJsonArray(from: Nullable<JsonCollection>, path: string): Nullable<JsonArray>;
+export function getJsonArray(from: Optional<AnyJson>, path: string): Nullable<JsonArray>;
 /**
- * Given a deep-search query path, returns an object property or array value of a {@link JsonCollection} as an
- * {@link AnyJson}, or `undefined` if a value was not found or was not type-compatible.
+ * Given a deep-search query path, returns an object property or array value from an {@link AnyJson} as a
+ * {@link JsonArray}, or the given default if a value was not found or was not type-compatible.
  *
  * ```
  * const obj = { foo: { bar: [1, 2, 3] } };
@@ -449,16 +435,12 @@ export function getJsonArray(from: Nullable<JsonCollection>, path: string): Null
  * // type of value -> JsonArray; value -> [4, 5, 6]
  * ```
  *
- * @param from The object or array to query.
+ * @param from The JSON value to query.
  * @param path The query path.
  * @param defaultValue The default to return if the query result was not defined.
  */
-export function getJsonArray(from: Nullable<JsonCollection>, path: string, defaultValue: JsonArray): JsonArray;
+export function getJsonArray(from: Optional<AnyJson>, path: string, defaultValue: JsonArray): JsonArray;
 // underlying function
-export function getJsonArray(
-  from: Nullable<JsonCollection>,
-  path: string,
-  defaultValue?: JsonArray
-): Nullable<JsonArray> {
+export function getJsonArray(from: Optional<AnyJson>, path: string, defaultValue?: JsonArray): Nullable<JsonArray> {
   return valueOrDefault(asJsonArray(getAnyJson(from, path)), defaultValue);
 }

--- a/packages/ts-types/src/narrowing/has.ts
+++ b/packages/ts-types/src/narrowing/has.ts
@@ -5,8 +5,19 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AnyArray, AnyConstructor, AnyFunction, Many, View } from '../types';
-import { isArray, isBoolean, isFunction, isNumber, isObject, isPlainObject, isString } from './is';
+import { AnyArray, AnyConstructor, AnyFunction, AnyJson, JsonArray, JsonMap, Many, Optional, View } from '../types';
+import {
+  isAnyJson,
+  isArray,
+  isBoolean,
+  isFunction,
+  isJsonArray,
+  isJsonMap,
+  isNumber,
+  isObject,
+  isPlainObject,
+  isString
+} from './is';
 
 /**
  * Tests whether a value of type `T` contains one or more property `keys`. If so, the type of the tested value is
@@ -29,7 +40,7 @@ import { isArray, isBoolean, isFunction, isNumber, isObject, isPlainObject, isSt
  * @param value The value to test.
  * @param keys One or more `string` keys to check for existence.
  */
-export function has<T, K extends string>(value: T, keys: Many<K>): value is T & View<K> {
+export function has<T extends unknown, K extends string>(value: T, keys: Many<K>): value is T & object & View<K> {
   return isObject(value) && (isArray(keys) ? keys.every(k => k in value) : keys in value);
 }
 
@@ -51,7 +62,10 @@ export function has<T, K extends string>(value: T, keys: Many<K>): value is T & 
  * @param value The value to test.
  * @param keys A `string` key to check for existence.
  */
-export function hasString<T, K extends string>(value: T, key: K): value is T & View<K, string> {
+export function hasString<T extends unknown, K extends string>(
+  value: T,
+  key: K
+): value is T & object & View<K, string> {
   return has(value, key) && isString(value[key]);
 }
 
@@ -73,7 +87,10 @@ export function hasString<T, K extends string>(value: T, key: K): value is T & V
  * @param value The value to test.
  * @param keys A `number` key to check for existence.
  */
-export function hasNumber<T, K extends string>(value: T, key: K): value is T & View<K, number> {
+export function hasNumber<T extends unknown, K extends string>(
+  value: T,
+  key: K
+): value is T & object & View<K, number> {
   return has(value, key) && isNumber(value[key]);
 }
 
@@ -95,7 +112,10 @@ export function hasNumber<T, K extends string>(value: T, key: K): value is T & V
  * @param value The value to test.
  * @param keys A `boolean` key to check for existence.
  */
-export function hasBoolean<T, K extends string>(value: T, key: K): value is T & View<K, boolean> {
+export function hasBoolean<T extends unknown, K extends string>(
+  value: T,
+  key: K
+): value is T & object & View<K, boolean> {
   return has(value, key) && isBoolean(value[key]);
 }
 
@@ -119,7 +139,10 @@ export function hasBoolean<T, K extends string>(value: T, key: K): value is T & 
  * @param value The value to test.
  * @param keys An `object` key to check for existence.
  */
-export function hasObject<T, K extends string>(value: T, key: K): value is T & View<K, object> {
+export function hasObject<T extends unknown, K extends string>(
+  value: T,
+  key: K
+): value is T & object & View<K, object> {
   return has(value, key) && isObject(value[key]);
 }
 
@@ -144,7 +167,10 @@ export function hasObject<T, K extends string>(value: T, key: K): value is T & V
  * @param value The value to test.
  * @param keys A "plain" `object` key to check for existence.
  */
-export function hasPlainObject<T, K extends string>(value: T, key: K): value is T & View<K, object> {
+export function hasPlainObject<T extends unknown, K extends string>(
+  value: T,
+  key: K
+): value is T & object & View<K, object> {
   return has(value, key) && isPlainObject(value[key]);
 }
 
@@ -170,8 +196,8 @@ export function hasPlainObject<T, K extends string>(value: T, key: K): value is 
  * @param value The value to test.
  * @param keys An instance of type `C` key to check for existence.
  */
-export function hasInstance<T, K extends string, C extends AnyConstructor>(
-  value: T,
+export function hasInstance<T extends unknown, K extends string, C extends AnyConstructor>(
+  value: Optional<T>,
   key: K,
   ctor: C
 ): value is T & View<K, InstanceType<C>> {
@@ -196,7 +222,10 @@ export function hasInstance<T, K extends string, C extends AnyConstructor>(
  * @param value The value to test.
  * @param keys An `AnyArray` key to check for existence.
  */
-export function hasArray<T, K extends string>(value: T, key: K): value is T & View<K, AnyArray> {
+export function hasArray<T extends unknown, K extends string>(
+  value: Optional<T>,
+  key: K
+): value is T & object & View<K, AnyArray> {
   return has(value, key) && isArray(value[key]);
 }
 
@@ -215,8 +244,81 @@ export function hasArray<T, K extends string>(value: T, key: K): value is T & Vi
  * ```
  *
  * @param value The value to test.
- * @param keys An `Array` key to check for existence.
+ * @param keys An `AnyFunction` key to check for existence.
  */
-export function hasFunction<T, K extends string>(value: T, key: K): value is T & View<K, AnyFunction> {
+export function hasFunction<T extends unknown, K extends string>(
+  value: Optional<T>,
+  key: K
+): value is T & object & View<K, AnyFunction> {
   return has(value, key) && isFunction(value[key]);
+}
+
+/**
+ * Tests whether a value of type `T` contains a property `key` of type {@link AnyJson}, _using a shallow test for
+ * `AnyJson` compatibility_ (see {@link isAnyJson} for more information). If so, the type of the
+ * tested value is narrowed to reflect the existence of that key for convenient access in the same scope. Returns
+ * `false` if the property key does not exist on the object or the value stored by that key is not of type
+ * {@link AnyJson}.
+ *
+ * ```
+ * // type of obj -> unknown
+ * if (hasAnyJson(obj, 'body')) {
+ *   // type of obj -> { body: AnyJson }
+ * }
+ * ```
+ *
+ * @param value The value to test.
+ * @param keys An `AnyJson` key to check for existence.
+ */
+export function hasAnyJson<T extends unknown, K extends string>(
+  value: Optional<T>,
+  key: K
+): value is T & object & View<K, AnyJson> {
+  return has(value, key) && isAnyJson(value[key]);
+}
+
+/**
+ * Tests whether a value of type `T extends AnyJson` contains a property `key` of type {@link JsonMap}. If so, the type
+ * of the tested value is narrowed to reflect the existence of that key for convenient access in the same scope. Returns
+ * `false` if the property key does not exist on the object or the value stored by that key is not of type
+ * {@link JsonMap}.
+ *
+ * ```
+ * // type of obj -> unknown
+ * if (hasJsonMap(obj, 'body')) {
+ *   // type of obj -> { body: JsonMap }
+ * }
+ * ```
+ *
+ * @param value The value to test.
+ * @param keys A `JsonMap` key to check for existence.
+ */
+export function hasJsonMap<T extends AnyJson, K extends string>(
+  value: Optional<T>,
+  key: K
+): value is T & JsonMap & View<K, JsonMap> {
+  return hasAnyJson(value, key) && isJsonMap(value[key]);
+}
+
+/**
+ * Tests whether a value of type `T extends AnyJson` contains a property `key` of type {@link JsonArray}. If so, the
+ * type of the tested value is narrowed to reflect the existence of that key for convenient access in the same scope.
+ * Returns `false` if the property key does not exist on the object or the value stored by that key is not of type
+ * {@link JsonArray}.
+ *
+ * ```
+ * // type of obj -> unknown
+ * if (hasJsonArray(obj, 'body')) {
+ *   // type of obj -> { body: JsonArray }
+ * }
+ * ```
+ *
+ * @param value The value to test.
+ * @param keys A `JsonArray` key to check for existence.
+ */
+export function hasJsonArray<T extends AnyJson, K extends string>(
+  value: Optional<T>,
+  key: K
+): value is T & JsonMap & View<K, JsonArray> {
+  return hasAnyJson(value, key) && isJsonArray(value[key]);
 }

--- a/packages/ts-types/src/types/collection.d.ts
+++ b/packages/ts-types/src/types/collection.d.ts
@@ -14,7 +14,8 @@ import { Optional } from './union';
 /**
  * An object with arbitrary string-indexed values of an optional generic type `Optional<T>`. `T` defaults to `unknown`
  * when not explicitly supplied. For convenient iteration of definitely assigned (i.e. non-nullable) entries, keys,
- * and values, see the following functions: {@link definiteEntries}, {@link definiteKeys}, and {@link definiteValues}.
+ * and values, see the following functions: {@link definiteEntriesOf}, {@link definiteKeysOf}, and
+ * {@link definiteValuesOf}.
  */
 export interface Dictionary<T = unknown> {
   [key: string]: Optional<T>;

--- a/packages/ts-types/src/types/mapped.d.ts
+++ b/packages/ts-types/src/types/mapped.d.ts
@@ -21,7 +21,7 @@ import { Literals } from './conditional';
  *
  * ```
  * enum QUERY_KEY { id, name, created, updated }
- * // typeof QUERY_KEY -> {
+ * // type of QUERY_KEY -> {
  * //     [x: number]: number;
  * //     readonly id: number;
  * //     readonly name: number;
@@ -29,7 +29,7 @@ import { Literals } from './conditional';
  * //     readonly updated: number;
  * // }
  * interface QueryRecord extends LiteralsRecord<typeof QUERY_KEY, string> { }
- * // typeof QueryRecord -> {
+ * // type of QueryRecord -> {
  * //     readonly id: string;
  * //     readonly name: string;
  * //     readonly created: string;
@@ -37,7 +37,7 @@ import { Literals } from './conditional';
  * // }
  * // And for an interface with writable properties, use the following:
  * interface QueryRecord extends ReadWrite<LiteralsRecord<typeof QUERY_KEY, string>> { }
- * // typeof QueryRecord -> {
+ * // type of QueryRecord -> {
  * //     id: string;
  * //     name: string;
  * //     created: string;
@@ -62,3 +62,17 @@ export type ReadWrite<T> = { -readonly [K in keyof T]: T[K] };
  * A view over an `object` with constrainable properties.
  */
 export type View<K extends string, V = unknown> = { [_ in K]: V };
+
+/**
+ * Returns a new type consisting of all properties declared for an input type `T2` overlaid on the
+ * properties of type `T1`. Any definitions in `T2` replace those previously defined in `T1`. This can
+ * be useful for redefining the types of properties on `T1` with values from an inline type `T2`, perhaps to
+ * change their type or to make them optional.
+ *
+ * ```
+ * type NameAndStringValue = { name: string, value: string }
+ * type NameAndOptionalNumericValue = Overwrite<NameAndValue, { value?: number }>
+ * // type of NameAndOptionalNumericValue -> { name: string } & { value?: number | undefined }
+ * ```
+ */
+export type Overwrite<T1, T2> = { [P in Exclude<keyof T1, keyof T2>]: T1[P] } & T2;

--- a/packages/ts-types/test/narrowing/has.test.ts
+++ b/packages/ts-types/test/narrowing/has.test.ts
@@ -8,12 +8,16 @@
 // tslint:disable:no-unused-expression
 
 import { expect } from 'chai';
+import { isAnyJson } from '../../src/narrowing';
 import {
   has,
+  hasAnyJson,
   hasArray,
   hasBoolean,
   hasFunction,
   hasInstance,
+  hasJsonArray,
+  hasJsonMap,
   hasNumber,
   hasObject,
   hasPlainObject,
@@ -30,6 +34,7 @@ describe('has type', () => {
   beforeEach(() => {
     obj = {
       u: undefined,
+      l: null,
       s: '',
       b: false,
       n: 0,
@@ -206,12 +211,106 @@ describe('has type', () => {
       }
     });
 
-    it('should narrow an unknown type to an object with an function property', () => {
+    it('should narrow an unknown type to an object with a function property', () => {
       if (!hasFunction(obj, 'f')) {
         throw new Error('object should have function property f');
       }
       // trivial runtime check but useful for compilation testing
       expect(obj.f).to.equal(obj.f);
+    });
+  });
+
+  describe('hasAnyJson', () => {
+    it('should not narrow an unknown type when checking a non-AnyJson property', () => {
+      if (hasAnyJson(obj, 'f')) {
+        throw new Error('object should not have AnyJson property f');
+      }
+    });
+
+    it('should narrow an unknown type to an object with an AnyJson property with a null value', () => {
+      if (!hasAnyJson(obj, 'l')) {
+        throw new Error('object should have AnyJson property l');
+      }
+      expect(obj.l).to.equal(null);
+    });
+
+    it('should narrow an unknown type to an object with an AnyJson property with a string value', () => {
+      if (!hasAnyJson(obj, 's')) {
+        throw new Error('object should have AnyJson property s');
+      }
+      expect(obj.s).to.equal('');
+    });
+
+    it('should narrow an unknown type to an object with an AnyJson property with a number value', () => {
+      if (!hasAnyJson(obj, 'n')) {
+        throw new Error('object should have AnyJson property n');
+      }
+      expect(obj.n).to.equal(0);
+    });
+
+    it('should narrow an unknown type to an object with an AnyJson property with a boolean value', () => {
+      if (!hasAnyJson(obj, 'b')) {
+        throw new Error('object should have AnyJson property b');
+      }
+      expect(obj.b).to.equal(false);
+    });
+
+    it('should narrow an unknown type to an object with an AnyJson with an object value', () => {
+      if (!hasAnyJson(obj, 'm')) {
+        throw new Error('object should have AnyJson property m');
+      }
+      expect(obj.m).to.deep.equal({});
+    });
+
+    it('should narrow an unknown type to an object with an AnyJson property with an array value', () => {
+      if (!hasAnyJson(obj, 'a')) {
+        throw new Error('object should have AnyJson property a');
+      }
+      expect(obj.a).to.deep.equal([]);
+    });
+  });
+
+  describe('hasJsonMap', () => {
+    it('should not narrow an unknown type when checking a non-JsonMap property', () => {
+      if (!isAnyJson(obj)) {
+        throw new Error('object must be narrowable to AnyJson');
+      }
+      if (hasJsonMap(obj, 'f')) {
+        throw new Error('object should not have JsonMap property f');
+      }
+    });
+
+    it('should narrow an unknown type to an object with a JsonMap property', () => {
+      if (!isAnyJson(obj)) {
+        throw new Error('object must be narrowable to AnyJson');
+      }
+      if (!hasJsonMap(obj, 'm')) {
+        throw new Error('object should have JsonMap property m');
+      }
+      // trivial runtime check but useful for compilation testing
+      expect(obj.m).to.equal(obj.m);
+    });
+  });
+
+  describe('hasJsonArray', () => {
+    it('should not narrow an unknown type when checking a non-JsonArray property', () => {
+      if (!isAnyJson(obj)) {
+        throw new Error('object must be narrowable to AnyJson');
+      }
+      if (hasJsonArray(obj, 'f')) {
+        throw new Error('object should not have JsonArray property f');
+      }
+    });
+
+    it('should narrow an unknown type to an object with a JsonArray property', () => {
+      if (!isAnyJson(obj)) {
+        throw new Error('object must be narrowable to AnyJson');
+      }
+      if (!hasJsonArray(obj, 'a')) {
+        throw new Error('object should have JsonArray property a');
+      }
+      // trivial runtime check but useful for compilation testing
+      expect(obj.a).to.equal(obj.a);
     });
   });
 });


### PR DESCRIPTION
Pete was asking some questions today about how to handle certain JSON processing scenarios and I realized that some of the `get*` and `has*` functions were less broadly applicable than I wanted.  I also found a few doc errors that get addressed in this update.