### PR TITLE
fix: make ci-docs target work for single repos like core

### DIFF
--- a/packages/dev-scripts/bin/sfdx-ci-docs.js
+++ b/packages/dev-scripts/bin/sfdx-ci-docs.js
@@ -9,33 +9,29 @@
 const shell = require('../utils/shelljs');
 const path = require('path');
 const packageRoot = require('../utils/package-path');
+const { isMultiPackageProject } = require('../utils/project-type');
 
-shell.exec('git fetch origin gh-pages:gh-pages', {
-  cwd: packageRoot
-});
+shell.set('-e');
 
-shell.exec('git worktree add docs gh-pages', {
-  cwd: packageRoot
-});
+shell.cd(packageRoot);
 
-shell.exec('yarn docs', {
-  cwd: packageRoot
-});
+shell.rm('-rf', 'docs');
+shell.exec('git worktree prune');
 
-shell.exec('cp README.md docs', {
-  cwd: packageRoot
-});
+shell.exec('git fetch origin gh-pages:gh-pages');
+shell.exec('git worktree add docs gh-pages');
+shell.exec('yarn docs');
+
+if (isMultiPackageProject(packageRoot)) {
+  shell.exec('cp README.md docs');
+}
 
 shell.set('+e');
-shell.exec('git add .', {
-  cwd: path.join(packageRoot, 'docs')
-});
 
-shell.exec('git commit -m "docs: publishing gh-pages"', {
-  cwd: path.join(packageRoot, 'docs')
-});
+shell.cd(path.join(packageRoot, 'docs'));
 
-shell.exec('git push origin gh-pages', {
-  cwd: path.join(packageRoot, 'docs')
-});
+shell.exec('git add .');
+shell.exec('git commit -m "docs: publishing gh-pages [skip ci]"');
+shell.exec('git push origin gh-pages');
+
 shell.set('-e');

--- a/packages/dev-scripts/utils/project-type.js
+++ b/packages/dev-scripts/utils/project-type.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const { join } = require('path');
+const { accessSync } = require('fs');
+
+exports.isMultiPackageProject = function(packageRoot) {
+  let isMulti = false;
+  try {
+    accessSync(join(packageRoot, 'lerna.json'));
+    isMulti = true;
+  } catch (err) {}
+  return isMulti;
+};

--- a/packages/dev-scripts/utils/standardize-files.js
+++ b/packages/dev-scripts/utils/standardize-files.js
@@ -6,11 +6,12 @@
  */
 
 const { join } = require('path');
-const { accessSync, writeFileSync } = require('fs');
+const { writeFileSync } = require('fs');
 const log = require('./log');
 const exists = require('./exists');
 const SfdxDevConfig = require('./sfdx-dev-config');
 const PackageJson = require('./package-json');
+const { isMultiPackageProject } = require('./project-type');
 
 const addFile = (filePath, strict, config) => {
   const fileExists = exists(filePath);
@@ -29,14 +30,8 @@ const addFile = (filePath, strict, config) => {
 
 module.exports = (packageRoot = require('./package-path'), inLernaProject) => {
   const config = new SfdxDevConfig(packageRoot);
-  let isLernaProject = false;
 
-  try {
-    accessSync(join(packageRoot, 'lerna.json'));
-    isLernaProject = true;
-  } catch (err) {}
-
-  if (isLernaProject) {
+  if (isMultiPackageProject(packageRoot)) {
     log('skipping writing files for learn project', 1);
     return;
   }

--- a/packages/dev-scripts/utils/standardize-pjson.js
+++ b/packages/dev-scripts/utils/standardize-pjson.js
@@ -5,21 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-const { accessSync } = require('fs');
-const { join } = require('path');
 const log = require('./log');
 const SfdxDevConfig = require('./sfdx-dev-config');
 const PackageJson = require('./package-json');
+const { isMultiPackageProject } = require('./project-type');
 
 module.exports = (packageRoot = require('./package-path'), inLernaProject) => {
   const config = new SfdxDevConfig(packageRoot);
   const pjson = new PackageJson(packageRoot);
-  let isLernaProject = false;
-
-  try {
-    accessSync(join(packageRoot, 'lerna.json'));
-    isLernaProject = true;
-  } catch (err) {}
 
   log(`standardizing scripts for ${pjson.name}`, 1);
 
@@ -33,7 +26,7 @@ module.exports = (packageRoot = require('./package-path'), inLernaProject) => {
     for (const script of scriptList) {
       const scriptName = Array.isArray(script) ? script[0] : script;
       const scriptFile = Array.isArray(script) ? script[1] : script;
-      if (isLernaProject) {
+      if (isMultiPackageProject(packageRoot)) {
         scripts[scriptName] = `lerna run ${scriptName}`;
       } else {
         let scriptArgs = scriptFile.split('-');


### PR DESCRIPTION
Need to retest in the lerna repos, but I think they should continue working as before.  Publishing core docs seem like the priority anyway.

Incidentally, this PR will now let you run `yarn ci-docs` locally to publish to `gh-pages` in case it ever needs to be done without going through the whole CI pipeline.
