### PR TITLE
fix(ts-sinon): allow stubs to be returned in async methods

### DIFF
--- a/packages/ts-sinon/src/index.ts
+++ b/packages/ts-sinon/src/index.ts
@@ -32,7 +32,7 @@ export type Stub<V extends OpenFunction> = V & SinonStub;
  */
 export type StubbedType<T extends object> = {
   // tslint:disable-next-line:no-any
-  [K in keyof T]: T[K] extends OpenFunction ? Stub<T[K]> : T[K]
+  [K in keyof T]: T[K] extends OpenFunction ? Stub<T[K]> : T[K];
 };
 
 /**
@@ -157,6 +157,10 @@ const makeProxyGet = (sandbox: SinonSandbox, members: OpenDictionary, stubMissin
       }
       return sandbox.stub().callsFake(fn);
     };
+    // We are not a promise.
+    if (target[name] == null && members[name] == null && name === 'then') {
+      return undefined;
+    }
     if (cache[name] != null) {
       return cache[name];
     }

--- a/packages/ts-sinon/test/index.test.ts
+++ b/packages/ts-sinon/test/index.test.ts
@@ -108,6 +108,25 @@ describe('stubs', () => {
     expect(result).to.equal(stub);
   });
 
+  it('should resolve a stub', async () => {
+    const stub = stubObject(sandbox, {});
+    expect(await Promise.resolve(stub)).to.equal(stub);
+  });
+
+  it('should stub when target has a then method', async () => {
+    const stub = stubObject<{ then: () => string }>(sandbox, {
+      then: () => 'test'
+    });
+    expect(stub.then()).to.equal('test');
+  });
+
+  it('should stub when members have a then method', async () => {
+    const stub = stubInterface<{ then: () => string }>(sandbox, {
+      then: () => 'test'
+    });
+    expect(stub.then()).to.equal('test');
+  });
+
   it('should stub a callable', () => {
     interface Callable {
       (): string;


### PR DESCRIPTION
When using ts-sinon, the following will hang:

```
const myobj = stubInterface(sandbox);
await Promise.resolve(myobj);
```

A more practice example is stubbing a async creatable class.

```
const maxRevision = stubInterface<MaxRevision>(sandbox);
stubMethod(sandbox, MaxRevision, 'getInstance').resolves(maxRevision);
```

Now the code that calls `await MaxRevision.getInstance()` will hang.