### PR TITLE
fix: export assert lib from ts-types

### DIFF
--- a/packages/ts-types/src/narrowing/index.ts
+++ b/packages/ts-types/src/narrowing/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './as';
+export * from './assert';
 export * from './coerce';
 export * from './ensure';
 export * from './get';


### PR DESCRIPTION
Forgot to export assert lib fns at top level.