### PR TITLE
chore: allow node params to pass through

### DIFF
--- a/packages/dev-scripts/bin/sf-test.js
+++ b/packages/dev-scripts/bin/sf-test.js
@@ -22,6 +22,7 @@ const command = `${nyc} mocha "${includes}"`;
 try {
   shell.exec(command, {
     cwd: packageRoot,
+    passthrough: true,
   });
 } catch (err) {
   process.exitCode = 1;


### PR DESCRIPTION
This is to support easy debugging.  E.g., `yarn test --inspect-brk`