### PR TITLE
fix: add minimum version check to dev-scripts

### DIFF
--- a/packages/dev-scripts/package.json
+++ b/packages/dev-scripts/package.json
@@ -55,7 +55,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-config-salesforce": "^0.1.0",
     "eslint-config-salesforce-license": "^0.1.0",
-    "eslint-config-salesforce-typescript": "^0.2.1",
+    "eslint-config-salesforce-typescript": "^0.2.0",
     "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jsdoc": "^27.0.3",

--- a/packages/dev-scripts/utils/write-dependencies.js
+++ b/packages/dev-scripts/utils/write-dependencies.js
@@ -19,6 +19,20 @@ module.exports = (projectPath, inLernaProject) => {
   const added = [];
   const removed = [];
 
+  const getVersionNum = (ver) => {
+    return (ver.startsWith('^') || ver.startsWith('~')) ? ver.slice(1) : ver;
+  }
+  const meetsMinimumVersion = (pjsonDepVersion, devScriptsDepVersion) => {
+    // First remove any carets and tildas
+    const pVersion = getVersionNum(pjsonDepVersion);
+    const dsVersion = getVersionNum(devScriptsDepVersion);
+    // Compare the version in package.json with the dev scripts version.
+    // result === -1 means the version in package.json < dev scripts version
+    // result === 0 means they match
+    // result === 1 means the version in package.json > dev scripts version
+    return pVersion.localeCompare(dsVersion, 'en-u-kn-true') > -1;
+  }
+
   const devScriptsPjson = require(join(__dirname, '..', 'package.json'));
   const add = (name, version) => {
     version = version || devScriptsPjson.dependencies[name] || devScriptsPjson.devDependencies[name];
@@ -28,7 +42,8 @@ module.exports = (projectPath, inLernaProject) => {
         `Version empty for ${name}. Make sure it is in the devDependencies in dev-scripts since it is being added to the actual projects devDependencies.`
       );
     }
-    if (!dependencies[name] || dependencies[name] !== version) {
+    // If the dependency min version has been met, ignore it.
+    if (!dependencies[name] || !meetsMinimumVersion(dependencies[name], version)) {
       dependencies[name] = version;
       added.push(name);
     }


### PR DESCRIPTION
Allow a dependency to have a version that is greater than the one specified by dev-scripts

@W-9022413@