### PR TITLE
fix: use existing published version of ts-types

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -27,7 +27,7 @@
     "test": "sf-test"
   },
   "dependencies": {
-    "@salesforce/ts-types": "^1.5.14",
+    "@salesforce/ts-types": "^1.5.13",
     "tslib": "^2.2.0"
   },
   "devDependencies": {

--- a/packages/ts-sinon/package.json
+++ b/packages/ts-sinon/package.json
@@ -12,7 +12,7 @@
     "lib/**/*.d.ts"
   ],
   "dependencies": {
-    "@salesforce/ts-types": "^1.5.14",
+    "@salesforce/ts-types": "^1.5.13",
     "sinon": "^5.1.1",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
this is meant to generate a new release to fix some errors with the last change