### PR TITLE
fix: rollback ts-types dependency for kit

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -27,7 +27,7 @@
     "test": "sf-test"
   },
   "dependencies": {
-    "@salesforce/ts-types": "^1.5.17",
+    "@salesforce/ts-types": "^1.5.13",
     "tslib": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
=> Found "@salesforce/plugin-templates#@salesforce/core#@salesforce/kit#@salesforce/ts-types@1.5.17"

- "@salesforce#plugin-templates#@salesforce#core#@salesforce#kit" depends on it
- "@salesforce#plugin-data#@salesforce#core#@salesforce#kit" depends on it

this should let  new version of `kit` use 1.5.13 like everybody else does.