### PR TITLE
fix: use oclif for manifest creation

### DIFF
--- a/packages/dev-scripts/bin/sf-prepack.js
+++ b/packages/dev-scripts/bin/sf-prepack.js
@@ -6,6 +6,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+const chalk = require('chalk');
 const shell = require('../utils/shelljs');
 const { isPlugin } = require('../utils/project-type');
 const packageRoot = require('../utils/package-path');
@@ -13,5 +14,13 @@ const packageRoot = require('../utils/package-path');
 shell.exec('yarn build');
 
 if (isPlugin(packageRoot)) {
-  shell.exec('oclif-dev manifest');
+  if (shell.which('oclif')) {
+    shell.exec('oclif manifest');
+  } else if (shell.which('oclif-dev')) {
+    shell.exec('oclif-dev manifest');
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(chalk.red('Failed:'), 'Cannot generate oclif.manifest.json because oclif is not installed.');
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
Tries to use `oclif` for manifest creation before defaulting to `oclif-dev`. Throws error if neither are installed

[skip-validate-pr]